### PR TITLE
Support Cluster Mode Enabled Redis Clusters

### DIFF
--- a/opencti-connectors/config/dev/variables.tfvars
+++ b/opencti-connectors/config/dev/variables.tfvars
@@ -14,7 +14,7 @@ log_retention   = "1"
 # -- OpenCTI Deployment -- #
 ############################
 # -- OpenCTI -- #
-opencti_version           = "5.3.8"
+opencti_version           = "5.7.2" # or 5.7.2 or greater
 opencti_connector_kms_arn = "" # Use the outputted KMS information from the Core OpenCTI deployment.
 opencti_platform_url      = "" # Use the outputted Internal Load Balancer information from the Core OpenCTI deployment.
 opencti_platform_port     = 4000

--- a/opencti/config/dev/variables.tfvars
+++ b/opencti/config/dev/variables.tfvars
@@ -64,12 +64,18 @@ opensearch_auto_tune = {
 #####################
 # -- Elasticache -- #
 #####################
-elasticache_instance_type                  = "cache.t4g.small"
-elasticache_replication_count              = 1
-elasticache_redis_version                  = "6.2"
+# Configurtion for Elasticache Redis cluster (cluster mode enabled)
+elasticache_instance_type                  = "cache.m6g.large"
+# Number of node groups (shards)
+elasticache_node_groups_count              = 2
+# Number of replicas per node group (shard)
+elasticache_replication_count              = 2
+elasticache_redis_version                  = "7.0"
+elasticache_parameter_group_name           = "default.redis7.cluster.on"
 elasticache_redis_port                     = "6379"
 elasticache_redis_snapshot_retention_limit = 1
-elasticache_redis_snapshot_time            = "18:00-20:00"
+# Time is in UTC, adjust accordingly
+elasticache_redis_snapshot_time            = "10:00-12:00"
 elasticache_redis_maintenance_period       = "sun:21:00-sun:23:00"
 redis_trimming                             = 200000 # Based off analysis
 
@@ -104,7 +110,7 @@ network_load_balancer_ips = [
 ############################
 
 # -- OpenCTI -- #
-opencti_version                      = "5.3.8"
+opencti_version                      = "5.7.2" # or 5.7.2 or greater
 public_opencti_access_logs_s3_prefix = "opencti-access-logs"
 # -- OpenCTI Platform -- #
 opencti_platform_port                  = 4000

--- a/opencti/modules/ecs_opencti/opencti_platform/main.tf
+++ b/opencti/modules/ecs_opencti/opencti_platform/main.tf
@@ -88,7 +88,11 @@ resource "aws_ecs_task_definition" "opencti-platform" {
         },
         {
           "name" : "REDIS__HOSTNAME",
-          "value" : "${var.elasticache_endpoint_address}"
+          "value" : "${split(":", var.elasticache_endpoint_address)[0]}"
+        },
+        {
+          "name" : "REDIS__HOSTNAMES",
+          "value" : "[\"${var.elasticache_endpoint_address}\"]"
         },
         {
           "name" : "REDIS__PORT",
@@ -97,6 +101,14 @@ resource "aws_ecs_task_definition" "opencti-platform" {
         {
           "name" : "REDIS__USE_SSL",
           "value" : "true"
+        },
+        {
+          "name" : "REDIS__MODE",
+          "value" : "cluster"
+        },
+        {
+          "name" : "REDIS__CA",
+          "value" : "[\"/etc/ssl/certs/ca-certificates.crt\"]"
         },
         {
           "name" : "REDIS__TRIMMING",

--- a/opencti/modules/elasticache/main.tf
+++ b/opencti/modules/elasticache/main.tf
@@ -8,7 +8,7 @@ resource "aws_elasticache_replication_group" "this" {
   multi_az_enabled           = true
   automatic_failover_enabled = true
 
-  num_node_groups         = 1
+  num_node_groups         = var.elasticache_node_groups_count
   replicas_per_node_group = var.elasticache_replication_count
 
   node_type                  = var.elasticache_instance_type
@@ -17,7 +17,7 @@ resource "aws_elasticache_replication_group" "this" {
   subnet_group_name          = aws_elasticache_subnet_group.this.name
   engine                     = "redis"
   engine_version             = var.elasticache_redis_version
-  parameter_group_name       = "default.redis6.x"
+  parameter_group_name       = var.elasticache_parameter_group_name
   maintenance_window         = var.elasticache_redis_maintenance_period
   auto_minor_version_upgrade = true
   apply_immediately          = true

--- a/opencti/modules/elasticache/output.tf
+++ b/opencti/modules/elasticache/output.tf
@@ -1,6 +1,6 @@
 output "elasticache_endpoint_address" {
-  value       = aws_elasticache_replication_group.this.primary_endpoint_address
-  description = "The Endpoint address for Elasticache redis for Read and Write Ops."
+  value       = aws_elasticache_replication_group.this.configuration_endpoint_address
+  description = "The configuration endpoint address for Elasticache Redis."
 }
 
 output "elasticache_credentials_arn" {

--- a/opencti/modules/elasticache/variables.tf
+++ b/opencti/modules/elasticache/variables.tf
@@ -44,13 +44,24 @@ variable "elasticache_instance_type" {
   description = "The instance type to host Elasticache on."
 }
 
+variable "elasticache_node_groups_count" {
+  type        = string
+  description = "The number of ElastiCache node groups (shards)."
+}
+
 variable "elasticache_replication_count" {
   type        = string
   description = "The number of replicated ElastiCache nodes."
 }
+
 variable "elasticache_redis_version" {
   type        = string
   description = "The Redis version to be used for AWS ElastiCache."
+}
+
+variable "elasticache_parameter_group_name" {
+  type        = string
+  description = "The Redis parameter group name to be used for AWS ElastiCache."
 }
 
 variable "elasticache_redis_port" {

--- a/opencti/variables.tf
+++ b/opencti/variables.tf
@@ -233,19 +233,29 @@ variable "elasticache_instance_type" {
   description = "The instance type to host Elasticache on."
 }
 
-variable "elasticache_redis_version" {
+variable "elasticache_node_groups_count" {
   type        = string
-  description = "The Redis version to be used for AWS ElastiCache."
-}
-
-variable "elasticache_redis_port" {
-  type        = string
-  description = "The port that the Redis Cluster will be accessible on."
+  description = "The number of ElastiCache node groups (shards)."
 }
 
 variable "elasticache_replication_count" {
   type        = string
   description = "The number of replicated ElastiCache nodes."
+}
+
+variable "elasticache_redis_version" {
+  type        = string
+  description = "The Redis version to be used for AWS ElastiCache."
+}
+
+variable "elasticache_parameter_group_name" {
+  type        = string
+  description = "The Redis parameter group name to be used for AWS ElastiCache."
+}
+
+variable "elasticache_redis_port" {
+  type        = string
+  description = "The port that the Redis Cluster will be accessible on."
 }
 
 variable "elasticache_redis_snapshot_retention_limit" {


### PR DESCRIPTION
These changes were made to support enabling and using cluster mode enabled Elasticache Redis clusters, now that OpenCTI is compatible. Additionally, improvements have been made to support allowing the configurator to specify the amount of shards (node groups) and the parameter group name for the cluster. Additionally, the default version of OpenCTI has been set to 5.7.2.